### PR TITLE
support emoji/icon shortcodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "author": "NothingIslost <[@nothingislost](https://github.com/nothingislost)>",
     "license": "MIT",
     "devDependencies": {
+        "@aidenlx/obsidian-icon-shortcodes": "^0.4.0",
         "@giotramu/prettier-config": "^1.1.2",
         "@rollup/plugin-commonjs": "^15.1.0",
         "@rollup/plugin-json": "^4.1.0",
@@ -20,6 +21,7 @@
         "@types/node": "^14.14.2",
         "@typescript-eslint/eslint-plugin": "^4.29.3",
         "@typescript-eslint/parser": "^4.29.3",
+        "assert-never": "^1.2.1",
         "codemirror": "^5.62.2",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",

--- a/src/hmd-fold-emoji.js
+++ b/src/hmd-fold-emoji.js
@@ -1,0 +1,166 @@
+// HyperMD, copyright (c) by laobubu
+// Distributed under an MIT license: http://laobubu.net/HyperMD/LICENSE
+//
+// DESCRIPTION: Fold and render emoji :smile:
+//
+const { getApi } = require("@aidenlx/obsidian-icon-shortcodes");
+(function (mod) {
+  //[HyperMD] UMD patched!
+  /*plain env*/ mod(
+    null,
+    (HyperMD.FoldEmoji = HyperMD.FoldEmoji || {}),
+    CodeMirror,
+    HyperMD,
+    HyperMD.Fold
+  );
+})(function (require, exports, CodeMirror, core_1, fold_1) {
+  "use strict";
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.defaultDict =
+    exports.defaultChecker =
+    exports.defaultRenderer =
+    exports.suggestedOption =
+    exports.EmojiFolder =
+    exports.getAddon =
+    exports.defaultOption =
+    exports.FoldEmoji =
+      void 0;
+  /********************************************************************************** */
+  //#region Folder
+  /**
+   * Detect if a token is emoji and fold it
+   *
+   * @see FolderFunc in ./fold.ts
+   */
+  const EmojiPattern = /\+1|-1|[\w-]+/,
+    AllowedChar = /^[\w-+]+$/;
+
+  exports.EmojiFolder = function (stream, token) {
+    if (token.string !== ":") return;
+    const nextColon = stream.findNext((t) => t.string === ":", false),
+      nextToken = stream.findNext(() => true);
+
+    // if nearest colon is next token, it's not an emoji
+    if (!nextToken || !nextColon || nextColon.i_token <= nextToken.i_token)
+      return;
+    let name = "";
+    for (let i = stream.i_token + 1; i < nextColon.i_token; i++) {
+      const t = stream.lineTokens[i];
+      // if warpped tokens not plain text, it's not an emoji
+      if (t.type !== null || !AllowedChar.test(t.string)) return;
+      name += t.string;
+    }
+    // filter text that is too long to be shortcode
+    if (name.length > 20) return;
+    // filter using common shortcode pattern
+    if (!EmojiPattern.test(name)) return;
+
+    var cm = stream.cm;
+    var addon = exports.getAddon(cm);
+    if (!addon.isEmoji(name)) return null;
+
+    var from = {
+      line: stream.lineNo,
+      ch: token.start,
+    };
+    var end = nextColon.token.end;
+    var to = { line: stream.lineNo, ch: end };
+
+    var reqAns = stream.requestRange(from, to);
+    if (reqAns !== fold_1.RequestRangeResult.OK) return null;
+    // now we are ready to fold and render!
+    var marker = addon.foldEmoji(name, from, to);
+    return marker;
+  };
+  //#endregion
+  fold_1.registerFolder("emoji", exports.EmojiFolder, true);
+  exports.defaultRenderer = (text) => {
+    const icon = getApi()?.getIcon(text);
+    if (!icon) {
+      return null;
+    } else if (typeof icon === "string") {
+      return createSpan({ text: icon });
+    } else {
+      return icon;
+    }
+  };
+  exports.defaultChecker = (text) => getApi()?.hasIcon(text) === true;
+  exports.defaultOption = {
+    myEmoji: {},
+    emojiRenderer: exports.defaultRenderer,
+    emojiChecker: exports.defaultChecker,
+  };
+  exports.suggestedOption = {};
+  core_1.suggestedEditorConfig.hmdFoldEmoji = exports.suggestedOption;
+  CodeMirror.defineOption(
+    "hmdFoldEmoji",
+    exports.defaultOption,
+    function (cm, newVal) {
+      ///// convert newVal's type to `Partial<Options>`, if it is not.
+      if (!newVal) {
+        newVal = {};
+      }
+      ///// apply config and write new values into cm
+      var inst = exports.getAddon(cm);
+      for (var k in exports.defaultOption) {
+        inst[k] = k in newVal ? newVal[k] : exports.defaultOption[k];
+      }
+    }
+  );
+  //#endregion
+  /********************************************************************************** */
+  //#region Addon Class
+  var FoldEmoji = /** @class */ (function (str) {
+    function FoldEmoji(cm) {
+      this.cm = cm;
+      // options will be initialized to defaultOption when constructor is finished
+    }
+    FoldEmoji.prototype.isEmoji = function (text) {
+      return text in this.myEmoji || this.emojiChecker(text);
+    };
+    FoldEmoji.prototype.foldEmoji = function (text, from, to) {
+      var cm = this.cm;
+      var el =
+        (text in this.myEmoji && this.myEmoji[text](text)) ||
+        this.emojiRenderer(text);
+      if (!el || !el.tagName) return null;
+      if (el.className.indexOf("hmd-emoji") === -1)
+        el.className += " hmd-emoji";
+      var marker = cm.markText(from, to, {
+        replacedWith: el,
+      });
+      el.addEventListener(
+        "click",
+        fold_1.breakMark.bind(this, cm, marker, 1),
+        false
+      );
+      if (el.tagName.toLowerCase() === "img") {
+        el.addEventListener(
+          "load",
+          function () {
+            return marker.changed();
+          },
+          false
+        );
+        el.addEventListener(
+          "dragstart",
+          function (ev) {
+            return ev.preventDefault();
+          },
+          false
+        );
+      }
+      return marker;
+    };
+    return FoldEmoji;
+  })();
+  exports.FoldEmoji = FoldEmoji;
+  //#endregion
+  /** ADDON GETTER (Singleton Pattern): a editor can have only one FoldEmoji instance */
+  exports.getAddon = core_1.Addon.Getter(
+    "FoldEmoji",
+    FoldEmoji,
+    exports.defaultOption /** if has options */
+  );
+});
+//#endregion

--- a/src/main.ts
+++ b/src/main.ts
@@ -401,10 +401,10 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
   }
 
   getHmdOptions(
-    type: "fold" | "foldCode",
+    type: "hmdFold" | "hmdFoldCode",
   ) {
     switch (type) {
-      case "fold": return ({
+      case "hmdFold": return ({
         image: this.settings.foldImages,
         link: this.settings.foldLinks,
         html: this.settings.renderHTML,
@@ -413,19 +413,18 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         embed: this.settings.renderEmbeds,
         emoji: this.settings.renderEmoji,
       });
-      case "foldCode": return {
-        image: this.settings.foldImages,
-        link: this.settings.foldLinks,
-        html: this.settings.renderHTML,
-        code: this.settings.renderCode,
-        math: this.settings.renderMath,
-        embed: this.settings.renderEmbeds,
+      case "hmdFoldCode": return {
+        admonition: this.settings.renderAdmonition,
+        chart: this.settings.renderChart,
+        query: this.settings.renderQuery,
+        dataview: this.settings.renderDataview,
+        tasks: this.settings.renderTasks,
       };
       default: assertNever(type);
     }
   }
   updateHmdOptions(type: Parameters<typeof this["getHmdOptions"]>[0]) {
-    return this.updateCodeMirrorOption("hmdFold", this.getHmdOptions(type));
+    return this.updateCodeMirrorOption(type, this.getHmdOptions(type));
   }
 
   registerCommands() {
@@ -465,7 +464,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.foldLinks = !this.settings.foldLinks;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("fold");
+        this.updateHmdOptions("hmdFold");
       },
     });
     this.addCommand({
@@ -475,7 +474,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.foldImages = !this.settings.foldImages;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("fold");
+        this.updateHmdOptions("hmdFold");
       },
     });
     this.addCommand({
@@ -485,7 +484,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderHTML = !this.settings.renderHTML;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("fold");
+        this.updateHmdOptions("hmdFold");
       },
     });
     this.addCommand({
@@ -495,7 +494,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderEmbeds = !this.settings.renderEmbeds;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("fold");
+        this.updateHmdOptions("hmdFold");
       },
     });
     this.addCommand({
@@ -505,7 +504,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderMath = !this.settings.renderMath;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("fold");
+        this.updateHmdOptions("hmdFold");
       },
     });
     this.addCommand({
@@ -537,7 +536,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderCode = !this.settings.renderCode;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("fold");
+        this.updateHmdOptions("hmdFold");
       },
     });
     this.addCommand({
@@ -547,7 +546,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderDataview = !this.settings.renderDataview;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("foldCode");
+        this.updateHmdOptions("hmdFoldCode");
       },
     });
     this.addCommand({
@@ -557,7 +556,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderChart = !this.settings.renderChart;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("foldCode");
+        this.updateHmdOptions("hmdFoldCode");
       },
     });
     this.addCommand({
@@ -567,7 +566,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderAdmonition = !this.settings.renderAdmonition;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("foldCode");
+        this.updateHmdOptions("hmdFoldCode");
       },
     });
     this.addCommand({
@@ -577,7 +576,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderQuery = !this.settings.renderQuery;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("foldCode");
+        this.updateHmdOptions("hmdFoldCode");
       },
     });
     this.addCommand({
@@ -587,7 +586,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderTasks = !this.settings.renderTasks;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateHmdOptions("foldCode");
+        this.updateHmdOptions("hmdFoldCode");
       },
     });
     this.addCommand({
@@ -771,8 +770,8 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
       cm.setOption("hmdClick", this.settings.editModeClickHandler);
       cm.setOption("hmdTableAlign", this.settings.autoAlignTables);
       cm.setOption("cursorBlinkRate", this.settings.cursorBlinkRate);
-      cm.setOption("hmdFold", this.getHmdOptions("fold"));
-      cm.setOption("hmdFoldCode", this.getHmdOptions("foldCode"));
+      cm.setOption("hmdFold", this.getHmdOptions("hmdFold"));
+      cm.setOption("hmdFoldCode", this.getHmdOptions("hmdFoldCode"));
       if (this.settings.renderMathPreview) init_math_preview(cm);
       if (this.settings.containerAttributes)
         this.updateCodeMirrorHandlers("renderLine", this.onRenderLineBound, true, true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+import assertNever from "assert-never";
 import { ObsidianCodeMirrorOptionsSettings, ObsidianCodeMirrorOptionsSettingsTab } from "./settings";
 import "./runmode";
 import "./colorize";
@@ -20,6 +21,7 @@ import "./hmd-fold-code-with-query";
 import "./hmd-fold-code-with-dataview";
 import "./hmd-fold-code-with-tasks";
 import "./hmd-fold-embed";
+import "./hmd-fold-emoji";
 import "./hmd-fold-math";
 import "./hmd-table-align";
 
@@ -398,6 +400,34 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
     this.register(patchRenderer);
   }
 
+  getHmdOptions(
+    type: "fold" | "foldCode",
+  ) {
+    switch (type) {
+      case "fold": return ({
+        image: this.settings.foldImages,
+        link: this.settings.foldLinks,
+        html: this.settings.renderHTML,
+        code: this.settings.renderCode,
+        math: this.settings.renderMath,
+        embed: this.settings.renderEmbeds,
+        emoji: this.settings.renderEmoji,
+      });
+      case "foldCode": return {
+        image: this.settings.foldImages,
+        link: this.settings.foldLinks,
+        html: this.settings.renderHTML,
+        code: this.settings.renderCode,
+        math: this.settings.renderMath,
+        embed: this.settings.renderEmbeds,
+      };
+      default: assertNever(type);
+    }
+  }
+  updateHmdOptions(type: Parameters<typeof this["getHmdOptions"]>[0]) {
+    return this.updateCodeMirrorOption("hmdFold", this.getHmdOptions(type));
+  }
+
   registerCommands() {
     this.addCommand({
       id: "toggle-openmd",
@@ -427,6 +457,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.updateCodeMirrorOption("hmdClick", this.settings.editModeClickHandler);
       },
     });
+
     this.addCommand({
       id: "toggle-collapse-links",
       name: "Toggle Collapse External Links",
@@ -434,14 +465,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.foldLinks = !this.settings.foldLinks;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFold", {
-          image: this.settings.foldImages,
-          link: this.settings.foldLinks,
-          html: this.settings.renderHTML,
-          code: this.settings.renderCode,
-          math: this.settings.renderMath,
-          embed: this.settings.renderEmbeds,
-        });
+        this.updateHmdOptions("fold");
       },
     });
     this.addCommand({
@@ -451,14 +475,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.foldImages = !this.settings.foldImages;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFold", {
-          image: this.settings.foldImages,
-          link: this.settings.foldLinks,
-          html: this.settings.renderHTML,
-          code: this.settings.renderCode,
-          math: this.settings.renderMath,
-          embed: this.settings.renderEmbeds,
-        });
+        this.updateHmdOptions("fold");
       },
     });
     this.addCommand({
@@ -468,14 +485,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderHTML = !this.settings.renderHTML;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFold", {
-          image: this.settings.foldImages,
-          link: this.settings.foldLinks,
-          html: this.settings.renderHTML,
-          code: this.settings.renderCode,
-          math: this.settings.renderMath,
-          embed: this.settings.renderEmbeds,
-        });
+        this.updateHmdOptions("fold");
       },
     });
     this.addCommand({
@@ -485,14 +495,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderEmbeds = !this.settings.renderEmbeds;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFold", {
-          image: this.settings.foldImages,
-          link: this.settings.foldLinks,
-          html: this.settings.renderHTML,
-          code: this.settings.renderCode,
-          math: this.settings.renderMath,
-          embed: this.settings.renderEmbeds,
-        });
+        this.updateHmdOptions("fold");
       },
     });
     this.addCommand({
@@ -502,14 +505,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderMath = !this.settings.renderMath;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFold", {
-          image: this.settings.foldImages,
-          link: this.settings.foldLinks,
-          html: this.settings.renderHTML,
-          code: this.settings.renderCode,
-          math: this.settings.renderMath,
-          embed: this.settings.renderEmbeds,
-        });
+        this.updateHmdOptions("fold");
       },
     });
     this.addCommand({
@@ -541,14 +537,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderCode = !this.settings.renderCode;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFold", {
-          image: this.settings.foldImages,
-          link: this.settings.foldLinks,
-          html: this.settings.renderHTML,
-          code: this.settings.renderCode,
-          math: this.settings.renderMath,
-          embed: this.settings.renderEmbeds,
-        });
+        this.updateHmdOptions("fold");
       },
     });
     this.addCommand({
@@ -558,13 +547,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderDataview = !this.settings.renderDataview;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFoldCode", {
-          admonition: this.settings.renderAdmonition,
-          chart: this.settings.renderChart,
-          query: this.settings.renderQuery,
-          dataview: this.settings.renderDataview,
-          tasks: this.settings.renderTasks,
-        });
+        this.updateHmdOptions("foldCode");
       },
     });
     this.addCommand({
@@ -574,13 +557,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderChart = !this.settings.renderChart;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFoldCode", {
-          admonition: this.settings.renderAdmonition,
-          chart: this.settings.renderChart,
-          query: this.settings.renderQuery,
-          dataview: this.settings.renderDataview,
-          tasks: this.settings.renderTasks,
-        });
+        this.updateHmdOptions("foldCode");
       },
     });
     this.addCommand({
@@ -590,13 +567,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderAdmonition = !this.settings.renderAdmonition;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFoldCode", {
-          admonition: this.settings.renderAdmonition,
-          chart: this.settings.renderChart,
-          query: this.settings.renderQuery,
-          dataview: this.settings.renderDataview,
-          tasks: this.settings.renderTasks,
-        });
+        this.updateHmdOptions("foldCode");
       },
     });
     this.addCommand({
@@ -606,13 +577,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderQuery = !this.settings.renderQuery;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFoldCode", {
-          admonition: this.settings.renderAdmonition,
-          chart: this.settings.renderChart,
-          query: this.settings.renderQuery,
-          dataview: this.settings.renderDataview,
-          tasks: this.settings.renderTasks,
-        });
+        this.updateHmdOptions("foldCode");
       },
     });
     this.addCommand({
@@ -622,13 +587,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
         this.settings.renderTasks = !this.settings.renderTasks;
         this.saveData(this.settings);
         this.applyBodyClasses();
-        this.updateCodeMirrorOption("hmdFoldCode", {
-          admonition: this.settings.renderAdmonition,
-          chart: this.settings.renderChart,
-          query: this.settings.renderQuery,
-          dataview: this.settings.renderDataview,
-          tasks: this.settings.renderTasks,
-        });
+        this.updateHmdOptions("foldCode");
       },
     });
     this.addCommand({
@@ -812,21 +771,8 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
       cm.setOption("hmdClick", this.settings.editModeClickHandler);
       cm.setOption("hmdTableAlign", this.settings.autoAlignTables);
       cm.setOption("cursorBlinkRate", this.settings.cursorBlinkRate);
-      cm.setOption("hmdFold", {
-        image: this.settings.foldImages,
-        link: this.settings.foldLinks,
-        html: this.settings.renderHTML,
-        code: this.settings.renderCode,
-        math: this.settings.renderMath,
-        embed: this.settings.renderEmbeds,
-      });
-      cm.setOption("hmdFoldCode", {
-        admonition: this.settings.renderAdmonition,
-        chart: this.settings.renderChart,
-        query: this.settings.renderQuery,
-        dataview: this.settings.renderDataview,
-        tasks: this.settings.renderTasks,
-      });
+      cm.setOption("hmdFold", this.getHmdOptions("fold"));
+      cm.setOption("hmdFoldCode", this.getHmdOptions("foldCode"));
       if (this.settings.renderMathPreview) init_math_preview(cm);
       if (this.settings.containerAttributes)
         this.updateCodeMirrorHandlers("renderLine", this.onRenderLineBound, true, true);
@@ -902,7 +848,7 @@ export default class ObsidianCodeMirrorOptionsPlugin extends Plugin {
     cm.setOption("styleActiveLine", true);
     cm.setOption("mode", "hypermd");
     cm.setOption("hmdHideToken", false);
-    cm.setOption("hmdFold", { image: false, link: false, html: false, code: false, math: false });
+    cm.setOption("hmdFold", { image: false, link: false, html: false, code: false, math: false, emoji: false });
     cm.setOption("hmdTableAlign", false);
     cm.setOption("hmdClick", false);
     cm.setOption("cursorBlinkRate", 530);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -161,7 +161,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
           this.plugin.settings.foldLinks = value;
           this.plugin.saveData(this.plugin.settings);
           this.plugin.applyBodyClasses();
-          this.plugin.updateHmdOptions("fold");
+          this.plugin.updateHmdOptions("hmdFold");
         })
       );
 
@@ -175,7 +175,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
           this.plugin.settings.foldImages = value;
           this.plugin.saveData(this.plugin.settings);
           this.plugin.applyBodyClasses();
-          this.plugin.updateHmdOptions("fold");
+          this.plugin.updateHmdOptions("hmdFold");
         })
       );
     new Setting(containerEl)
@@ -210,7 +210,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderEmbeds).onChange(value => {
           this.plugin.settings.renderEmbeds = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("fold");
+          this.plugin.updateHmdOptions("hmdFold");
         })
       );
     new Setting(containerEl)
@@ -220,7 +220,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderHTML).onChange(value => {
           this.plugin.settings.renderHTML = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("fold");
+          this.plugin.updateHmdOptions("hmdFold");
         })
       );
     new Setting(containerEl)
@@ -230,7 +230,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderMath).onChange(value => {
           this.plugin.settings.renderMath = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("fold");
+          this.plugin.updateHmdOptions("hmdFold");
         })
       );
     new Setting(containerEl)
@@ -262,7 +262,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderCode).onChange(value => {
           this.plugin.settings.renderCode = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("fold");
+          this.plugin.updateHmdOptions("hmdFold");
         })
       );
     new Setting(containerEl)
@@ -297,7 +297,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderAdmonition).onChange(value => {
           this.plugin.settings.renderAdmonition = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("foldCode");
+          this.plugin.updateHmdOptions("hmdFoldCode");
         })
       );
     new Setting(containerEl)
@@ -307,7 +307,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderChart).onChange(value => {
           this.plugin.settings.renderChart = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("foldCode");
+          this.plugin.updateHmdOptions("hmdFoldCode");
         })
       );
     new Setting(containerEl)
@@ -317,7 +317,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderQuery).onChange(value => {
           this.plugin.settings.renderQuery = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("foldCode");
+          this.plugin.updateHmdOptions("hmdFoldCode");
         })
       );
     new Setting(containerEl)
@@ -327,7 +327,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderDataview).onChange(value => {
           this.plugin.settings.renderDataview = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("foldCode");
+          this.plugin.updateHmdOptions("hmdFoldCode");
         })
       );
     new Setting(containerEl)
@@ -337,7 +337,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderTasks).onChange(value => {
           this.plugin.settings.renderTasks = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateHmdOptions("foldCode");
+          this.plugin.updateHmdOptions("hmdFoldCode");
         })
       );
     new Setting(containerEl)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -33,6 +33,7 @@ export class ObsidianCodeMirrorOptionsSettings {
   renderBanner: boolean;
   renderTasks: boolean;
   renderEmbeds: boolean;
+  renderEmoji: boolean;
   showBacklinks: boolean;
   styleCheckBox: boolean;
   allowedYamlKeys: string;
@@ -66,6 +67,7 @@ export const DEFAULT_SETTINGS: ObsidianCodeMirrorOptionsSettings = {
   renderMathPreview: false,
   renderBanner: false,
   renderEmbeds: false,
+  renderEmoji: false,
   renderTasks: false,
   showBacklinks: false,
   styleCheckBox: true,
@@ -159,14 +161,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
           this.plugin.settings.foldLinks = value;
           this.plugin.saveData(this.plugin.settings);
           this.plugin.applyBodyClasses();
-          this.plugin.updateCodeMirrorOption("hmdFold", {
-            image: this.plugin.settings.foldImages,
-            link: this.plugin.settings.foldLinks,
-            html: this.plugin.settings.renderHTML,
-            code: this.plugin.settings.renderCode,
-            math: this.plugin.settings.renderMath,
-            embed: this.plugin.settings.renderEmbeds,
-          });
+          this.plugin.updateHmdOptions("fold");
         })
       );
 
@@ -180,14 +175,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
           this.plugin.settings.foldImages = value;
           this.plugin.saveData(this.plugin.settings);
           this.plugin.applyBodyClasses();
-          this.plugin.updateCodeMirrorOption("hmdFold", {
-            image: this.plugin.settings.foldImages,
-            link: this.plugin.settings.foldLinks,
-            html: this.plugin.settings.renderHTML,
-            code: this.plugin.settings.renderCode,
-            math: this.plugin.settings.renderMath,
-            embed: this.plugin.settings.renderEmbeds,
-          });
+          this.plugin.updateHmdOptions("fold");
         })
       );
     new Setting(containerEl)
@@ -222,14 +210,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderEmbeds).onChange(value => {
           this.plugin.settings.renderEmbeds = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFold", {
-            image: this.plugin.settings.foldImages,
-            link: this.plugin.settings.foldLinks,
-            html: this.plugin.settings.renderHTML,
-            code: this.plugin.settings.renderCode,
-            math: this.plugin.settings.renderMath,
-            embed: this.plugin.settings.renderEmbeds,
-          });
+          this.plugin.updateHmdOptions("fold");
         })
       );
     new Setting(containerEl)
@@ -239,14 +220,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderHTML).onChange(value => {
           this.plugin.settings.renderHTML = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFold", {
-            image: this.plugin.settings.foldImages,
-            link: this.plugin.settings.foldLinks,
-            html: this.plugin.settings.renderHTML,
-            code: this.plugin.settings.renderCode,
-            math: this.plugin.settings.renderMath,
-            embed: this.plugin.settings.renderEmbeds,
-          });
+          this.plugin.updateHmdOptions("fold");
         })
       );
     new Setting(containerEl)
@@ -256,14 +230,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderMath).onChange(value => {
           this.plugin.settings.renderMath = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFold", {
-            image: this.plugin.settings.foldImages,
-            link: this.plugin.settings.foldLinks,
-            html: this.plugin.settings.renderHTML,
-            code: this.plugin.settings.renderCode,
-            math: this.plugin.settings.renderMath,
-            embed: this.plugin.settings.renderEmbeds,
-          });
+          this.plugin.updateHmdOptions("fold");
         })
       );
     new Setting(containerEl)
@@ -295,13 +262,31 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderCode).onChange(value => {
           this.plugin.settings.renderCode = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFold", {
-            image: this.plugin.settings.foldImages,
-            link: this.plugin.settings.foldLinks,
-            html: this.plugin.settings.renderHTML,
-            code: this.plugin.settings.renderCode,
-            math: this.plugin.settings.renderMath,
-            embed: this.plugin.settings.renderEmbeds,
+          this.plugin.updateHmdOptions("fold");
+        })
+      );
+    new Setting(containerEl)
+      .setName("Render Emoji/Icon Shortcodes")
+      .setDesc(
+        createFragment((el) => {
+          el.appendText(`Render emoji/icon `);
+          el.createEl("code", { text: ":shortcodes:" });
+          el.appendText(` inline.`);
+          el.createEl("br");
+          el.createEl("a", {
+            href: "https://github.com/aidenlx/obsidian-icon-shortcodes",
+            text: "Icon Shortcodes v0.4.1+",
+          });
+          el.appendText(" Required. ");
+        })
+      )
+      .addToggle(toggle =>
+        toggle.setValue(this.plugin.settings.renderEmoji).onChange(value => {
+          this.plugin.settings.renderEmoji = value;
+          this.plugin.saveData(this.plugin.settings);
+          this.plugin.applyBodyClasses();
+          this.app.workspace.iterateCodeMirrors(cm => {
+            cm.refresh();
           });
         })
       );
@@ -312,13 +297,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderAdmonition).onChange(value => {
           this.plugin.settings.renderAdmonition = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFoldCode", {
-            admonition: this.plugin.settings.renderAdmonition,
-            chart: this.plugin.settings.renderChart,
-            query: this.plugin.settings.renderQuery,
-            dataview: this.plugin.settings.renderDataview,
-            tasks: this.plugin.settings.renderTasks,
-          });
+          this.plugin.updateHmdOptions("foldCode");
         })
       );
     new Setting(containerEl)
@@ -328,13 +307,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderChart).onChange(value => {
           this.plugin.settings.renderChart = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFoldCode", {
-            admonition: this.plugin.settings.renderAdmonition,
-            chart: this.plugin.settings.renderChart,
-            query: this.plugin.settings.renderQuery,
-            dataview: this.plugin.settings.renderDataview,
-            tasks: this.plugin.settings.renderTasks,
-          });
+          this.plugin.updateHmdOptions("foldCode");
         })
       );
     new Setting(containerEl)
@@ -344,13 +317,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderQuery).onChange(value => {
           this.plugin.settings.renderQuery = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFoldCode", {
-            admonition: this.plugin.settings.renderAdmonition,
-            chart: this.plugin.settings.renderChart,
-            query: this.plugin.settings.renderQuery,
-            dataview: this.plugin.settings.renderDataview,
-            tasks: this.plugin.settings.renderTasks,
-          });
+          this.plugin.updateHmdOptions("foldCode");
         })
       );
     new Setting(containerEl)
@@ -360,13 +327,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderDataview).onChange(value => {
           this.plugin.settings.renderDataview = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFoldCode", {
-            admonition: this.plugin.settings.renderAdmonition,
-            chart: this.plugin.settings.renderChart,
-            query: this.plugin.settings.renderQuery,
-            dataview: this.plugin.settings.renderDataview,
-            tasks: this.plugin.settings.renderTasks,
-          });
+          this.plugin.updateHmdOptions("foldCode");
         })
       );
     new Setting(containerEl)
@@ -376,13 +337,7 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.renderTasks).onChange(value => {
           this.plugin.settings.renderTasks = value;
           this.plugin.saveData(this.plugin.settings);
-          this.plugin.updateCodeMirrorOption("hmdFoldCode", {
-            admonition: this.plugin.settings.renderAdmonition,
-            chart: this.plugin.settings.renderChart,
-            query: this.plugin.settings.renderQuery,
-            dataview: this.plugin.settings.renderDataview,
-            tasks: this.plugin.settings.renderTasks,
-          });
+          this.plugin.updateHmdOptions("foldCode");
         })
       );
     new Setting(containerEl)


### PR DESCRIPTION
implemented #81 ([obsidian-icon-shortcodes v0.4.1+](https://github.com/aidenlx/obsidian-icon-shortcodes/releases/tag/0.4.1) required)

- Add `hmd-fold-emoji` add-on adapted from <https://github.com/laobubu/HyperMD/blob/master/src/addon/fold-emoji.ts>
- Add `getHmdOptions()` and `updateHmdOptions()` method to simplify refresh process