### PR TITLE
fix: fold emoji should now work on non-paragraph tokens

### DIFF
--- a/src/hmd-fold-emoji.js
+++ b/src/hmd-fold-emoji.js
@@ -44,11 +44,14 @@ const { getApi } = require("@aidenlx/obsidian-icon-shortcodes");
     // if nearest colon is next token, it's not an emoji
     if (!nextToken || !nextColon || nextColon.i_token <= nextToken.i_token)
       return;
+
+    const tokenType = token.type;
     let name = "";
     for (let i = stream.i_token + 1; i < nextColon.i_token; i++) {
       const t = stream.lineTokens[i];
-      // if warpped tokens not plain text, it's not an emoji
-      if (t.type !== null || !AllowedChar.test(t.string)) return;
+      // if type of warpped tokens not the same as leading colon,
+      // it's not an emoji
+      if (t.type !== tokenType || !AllowedChar.test(t.string)) return;
       name += t.string;
     }
     // filter text that is too long to be shortcode

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -264,16 +264,6 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
           })
         );
       new Setting(containerEl)
-        .setName("Render Code Blocks")
-        .setDesc(`If this is disabled, none of the options below will do anything`)
-        .addToggle(toggle =>
-          toggle.setValue(this.plugin.settings.renderCode).onChange(value => {
-            this.plugin.settings.renderCode = value;
-            this.plugin.saveData(this.plugin.settings);
-            this.plugin.updateHmdOptions("hmdFold");
-          })
-        );
-      new Setting(containerEl)
         .setName("Render Emoji/Icon Shortcodes")
         .setDesc(
           createFragment(el => {
@@ -296,6 +286,16 @@ export class ObsidianCodeMirrorOptionsSettingsTab extends PluginSettingTab {
             this.app.workspace.iterateCodeMirrors(cm => {
               cm.refresh();
             });
+          })
+        );
+      new Setting(containerEl)
+        .setName("Render Code Blocks")
+        .setDesc(`If this is disabled, none of the options below will do anything`)
+        .addToggle(toggle =>
+          toggle.setValue(this.plugin.settings.renderCode).onChange(value => {
+            this.plugin.settings.renderCode = value;
+            this.plugin.saveData(this.plugin.settings);
+            this.plugin.updateHmdOptions("hmdFold");
           })
         );
       new Setting(containerEl)


### PR DESCRIPTION
- emoji shortcodes should be rendered on list, quote, link etc... with this patch
- adjust setting option order to avoid misunderstanding, as emoji renderer do not require code block renderer to be enabled